### PR TITLE
Throttle the requests using fetch-throttle.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,10 +1,12 @@
 import fetch from 'node-fetch';
+import throttle from 'fetch-throttle';
+const fetchMCC = throttle(fetch, 40, 60*1000);
 
 export default class MCCAPI {
     private static BASE_URL = "https://api.mcchampionship.com/v1";
 
     private static async request(endpoint: string): Promise<unknown> {
-        const response = await fetch(`${this.BASE_URL}/${endpoint}`)
+        const response = await fetchMCC(`${this.BASE_URL}/${endpoint}`)
         return await response.json()
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "fetch-throttle": "^0.1.0",
         "node-fetch": "^3.2.6"
       },
       "devDependencies": {
-        "@types/node": "^18.0.0"
+        "@types/node": "^18.0.0",
+        "typescript": "^4.7.4"
       }
     },
     "node_modules/@types/node": {
@@ -50,6 +52,11 @@
       "engines": {
         "node": "^12.20 || >= 14.13"
       }
+    },
+    "node_modules/fetch-throttle": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/fetch-throttle/-/fetch-throttle-0.1.0.tgz",
+      "integrity": "sha512-mlaZlmpIB3qThnrkhuo7BZJbzZrrIDhIl+g1QfJa2P+aWyfvxOSMCxok5vPK8u73SVq7x4ROLI0wmQvUeVRQwQ=="
     },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
@@ -97,6 +104,19 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
@@ -127,6 +147,11 @@
         "web-streams-polyfill": "^3.0.3"
       }
     },
+    "fetch-throttle": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/fetch-throttle/-/fetch-throttle-0.1.0.tgz",
+      "integrity": "sha512-mlaZlmpIB3qThnrkhuo7BZJbzZrrIDhIl+g1QfJa2P+aWyfvxOSMCxok5vPK8u73SVq7x4ROLI0wmQvUeVRQwQ=="
+    },
     "formdata-polyfill": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
@@ -149,6 +174,12 @@
         "fetch-blob": "^3.1.4",
         "formdata-polyfill": "^4.0.10"
       }
+    },
+    "typescript": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "dev": true
     },
     "web-streams-polyfill": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "type": "module",
   "license": "MIT",
   "dependencies": {
+    "fetch-throttle": "^0.1.0",
     "node-fetch": "^3.2.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Hey niklaas, you might recognise me as diggity(dingdong) from testing a couple years ago. Anyways, this change will throttle the API requests to 40 per minute as documented. Prevents nasty 429 errors (and subsequent type safety).

Not sure why there's random package-lock.json discrepancies, npm must've fiddled with it automatically. Did my best, but its late here...

Note that I'm not sure if this accounts for cached node-fetch results (1. if it even caches and 2. throttles the same request even though it's already cached)